### PR TITLE
Support dynamic column policy on crate `create table` statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.22.0
+
+- Add support for generating `CREATE TABLE IF NOT EXISTS (...fields) WITH (column_policy = 'dynamic')`
+  when json schema has `additionalProperties` set to true at the root
+
 # 0.21.2
 
 - Fixed an issue when updating a nested field like `foo.bar` or `foo.0.bar`.
@@ -71,7 +76,7 @@
 # 0.9.0
 
 - Changed `convertSchema` to accept `omit` and `overrides`.
-`overrides` allow you to override the bsonType of any path.
+  `overrides` allow you to override the bsonType of any path.
 
 # 0.8.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mongo2crate",
-  "version": "0.21.2",
+  "version": "0.22.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mongo2crate",
-      "version": "0.21.2",
+      "version": "0.22.0",
       "license": "ISC",
       "dependencies": {
         "debug": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo2crate",
-  "version": "0.21.2",
+  "version": "0.22.0",
   "description": "Sync MongoDB to CrateDB and Convert JSON schema to SQL DDL",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/convertSchema.test.ts
+++ b/src/convertSchema.test.ts
@@ -73,6 +73,18 @@ const schema = {
   },
 }
 
+const dynamicColumnSchema = {
+  bsonType: 'object',
+  additionalProperties: true,
+  required: ['name'],
+  properties: {
+    _id: {
+      bsonType: 'objectId',
+    },
+    name: { bsonType: ['string', 'null'] },
+  },
+}
+
 describe('convertSchema', () => {
   it('should convert the schema', () => {
     expect(convertSchema(schema, '"doc"."foobar"'))
@@ -107,6 +119,13 @@ describe('convertSchema', () => {
   ),
   "metadata" OBJECT(IGNORED)
 )`)
+  })
+  it('should convert the schema with dynamic column policy', () => {
+    expect(convertSchema(dynamicColumnSchema, '"doc"."foobar_dynamic"'))
+      .toEqual(`CREATE TABLE IF NOT EXISTS "doc"."foobar_dynamic" (
+  "id" TEXT PRIMARY KEY,
+  "name" TEXT
+) WITH (column_policy = 'dynamic')`)
   })
   it('should omit fields from the schema', () => {
     expect(

--- a/src/convertSchema.ts
+++ b/src/convertSchema.ts
@@ -52,7 +52,10 @@ const _convertSchema = (nodes: Node[], spacing = ''): string => {
       return (
         'CREATE TABLE IF NOT EXISTS %s (\n' +
         _convertSchema(nodes.slice(1), padding) +
-        ')'
+        ')' +
+        (node.val.additionalProperties
+          ? " WITH (column_policy = 'dynamic')"
+          : '')
       )
     }
     // Scalar fields, including objects with no defined fields


### PR DESCRIPTION
- Add support for generating `CREATE TABLE IF NOT EXISTS (...fields) WITH (column_policy = 'dynamic')` when json schema has `additionalProperties` set to true at the root

https://crate.io/docs/crate/reference/en/5.1/general/ddl/column-policy.html#dynamic