### PR TITLE
`rename` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.41.0
 
-- Removed `options.mapper` in favor of `rename` which takes an object of keys to be renamed.
+- Removed `options.mapper` in favor of `options.rename` which takes an object of keys to be renamed.
+The `rename` option is available for syncing and converting a schema to a table.
 
 # 0.40.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.41.0
 
-- Removed `options.mapper` in favor of `options.rename` which takes an object of keys to be renamed.
+- Removed `options.mapper` in favor of `options.rename` which takes an object of dotted path to renamed dotted path.
 The `rename` option is available for syncing and converting a schema to a table.
 
 # 0.40.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.41.0
+
+- Removed `options.mapper` in favor of `rename` which takes an object of keys to be renamed.
+
 # 0.40.0
 
 - Latest `mongochangestream` - Change stream option `operationTypes` (`insert`, `update`, `delete`, ...).

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,9 @@
       "license": "ISC",
       "dependencies": {
         "debug": "^4.3.4",
+        "dupes-of-hazard": "^0.1.0",
         "eventemitter3": "^5.0.1",
-        "json-stable-stringify": "^1.0.2",
         "lodash": "^4.17.21",
-        "make-error": "^1.3.6",
         "minimatch": "^6.2.0",
         "mongochangestream": "^0.43.0",
         "node-fetch": "^3.2.8",
@@ -24,7 +23,6 @@
       "devDependencies": {
         "@types/debug": "^4.1.7",
         "@types/jest": "^28.1.6",
-        "@types/json-stable-stringify": "^1.0.34",
         "@types/lodash": "^4.14.182",
         "@typescript-eslint/eslint-plugin": "^5.59.1",
         "eslint": "^8.39.0",
@@ -1362,12 +1360,6 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
     },
-    "node_modules/@types/json-stable-stringify": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/@types/json-stable-stringify/-/json-stable-stringify-1.0.34.tgz",
-      "integrity": "sha512-s2cfwagOQAS8o06TcwKfr9Wx11dNGbH2E9vJz1cqV+a/LOyhWNLUNd6JSRYNzvB4d29UuJX2M0Dj9vE1T8fRXw==",
-      "dev": true
-    },
     "node_modules/@types/lodash": {
       "version": "4.14.184",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.184.tgz",
@@ -2408,6 +2400,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dupes-of-hazard": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dupes-of-hazard/-/dupes-of-hazard-0.1.0.tgz",
+      "integrity": "sha512-c3M/IAoVi0J29/Aml2DsQGJbtiuUPiPByFyc8e200c+438K3TBam9zLD4pK7I9UpsYnABuYX66BwoeRsd6inlg==",
+      "dependencies": {
+        "json-stable-stringify": "^1.0.2",
+        "make-error": "^1.3.6"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -6631,12 +6632,6 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
     },
-    "@types/json-stable-stringify": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/@types/json-stable-stringify/-/json-stable-stringify-1.0.34.tgz",
-      "integrity": "sha512-s2cfwagOQAS8o06TcwKfr9Wx11dNGbH2E9vJz1cqV+a/LOyhWNLUNd6JSRYNzvB4d29UuJX2M0Dj9vE1T8fRXw==",
-      "dev": true
-    },
     "@types/lodash": {
       "version": "4.14.184",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.184.tgz",
@@ -7332,6 +7327,15 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
+      }
+    },
+    "dupes-of-hazard": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dupes-of-hazard/-/dupes-of-hazard-0.1.0.tgz",
+      "integrity": "sha512-c3M/IAoVi0J29/Aml2DsQGJbtiuUPiPByFyc8e200c+438K3TBam9zLD4pK7I9UpsYnABuYX66BwoeRsd6inlg==",
+      "requires": {
+        "json-stable-stringify": "^1.0.2",
+        "make-error": "^1.3.6"
       }
     },
     "electron-to-chromium": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,9 @@
       "dependencies": {
         "debug": "^4.3.4",
         "eventemitter3": "^5.0.1",
+        "json-stable-stringify": "^1.0.2",
         "lodash": "^4.17.21",
+        "make-error": "^1.3.6",
         "minimatch": "^6.2.0",
         "mongochangestream": "^0.43.0",
         "node-fetch": "^3.2.8",
@@ -22,6 +24,7 @@
       "devDependencies": {
         "@types/debug": "^4.1.7",
         "@types/jest": "^28.1.6",
+        "@types/json-stable-stringify": "^1.0.34",
         "@types/lodash": "^4.14.182",
         "@typescript-eslint/eslint-plugin": "^5.59.1",
         "eslint": "^8.39.0",
@@ -1357,6 +1360,12 @@
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "dev": true
+    },
+    "node_modules/@types/json-stable-stringify": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/@types/json-stable-stringify/-/json-stable-stringify-1.0.34.tgz",
+      "integrity": "sha512-s2cfwagOQAS8o06TcwKfr9Wx11dNGbH2E9vJz1cqV+a/LOyhWNLUNd6JSRYNzvB4d29UuJX2M0Dj9vE1T8fRXw==",
       "dev": true
     },
     "node_modules/@types/lodash": {
@@ -3986,6 +3995,17 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.2.tgz",
+      "integrity": "sha512-eunSSaEnxV12z+Z73y/j5N37/In40GK4GmsSy+tEHJMxknvqnA7/djeYtAgW0GsWHUfg+847WJjKaEylk2y09g==",
+      "dependencies": {
+        "jsonify": "^0.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -4002,6 +4022,14 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/kleur": {
@@ -6603,6 +6631,12 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
     },
+    "@types/json-stable-stringify": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/@types/json-stable-stringify/-/json-stable-stringify-1.0.34.tgz",
+      "integrity": "sha512-s2cfwagOQAS8o06TcwKfr9Wx11dNGbH2E9vJz1cqV+a/LOyhWNLUNd6JSRYNzvB4d29UuJX2M0Dj9vE1T8fRXw==",
+      "dev": true
+    },
     "@types/lodash": {
       "version": "4.14.184",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.184.tgz",
@@ -8485,6 +8519,14 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
+    "json-stable-stringify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.2.tgz",
+      "integrity": "sha512-eunSSaEnxV12z+Z73y/j5N37/In40GK4GmsSy+tEHJMxknvqnA7/djeYtAgW0GsWHUfg+847WJjKaEylk2y09g==",
+      "requires": {
+        "jsonify": "^0.0.1"
+      }
+    },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -8496,6 +8538,11 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
       "dev": true
+    },
+    "jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg=="
     },
     "kleur": {
       "version": "3.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mongo2crate",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mongo2crate",
-      "version": "0.40.0",
+      "version": "0.41.0",
       "license": "ISC",
       "dependencies": {
         "debug": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "devDependencies": {
     "@types/debug": "^4.1.7",
     "@types/jest": "^28.1.6",
-    "@types/json-stable-stringify": "^1.0.34",
     "@types/lodash": "^4.14.182",
     "@typescript-eslint/eslint-plugin": "^5.59.1",
     "eslint": "^8.39.0",
@@ -50,10 +49,9 @@
   },
   "dependencies": {
     "debug": "^4.3.4",
+    "dupes-of-hazard": "^0.1.0",
     "eventemitter3": "^5.0.1",
-    "json-stable-stringify": "^1.0.2",
     "lodash": "^4.17.21",
-    "make-error": "^1.3.6",
     "minimatch": "^6.2.0",
     "mongochangestream": "^0.43.0",
     "node-fetch": "^3.2.8",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@types/debug": "^4.1.7",
     "@types/jest": "^28.1.6",
+    "@types/json-stable-stringify": "^1.0.34",
     "@types/lodash": "^4.14.182",
     "@typescript-eslint/eslint-plugin": "^5.59.1",
     "eslint": "^8.39.0",
@@ -50,7 +51,9 @@
   "dependencies": {
     "debug": "^4.3.4",
     "eventemitter3": "^5.0.1",
+    "json-stable-stringify": "^1.0.2",
     "lodash": "^4.17.21",
+    "make-error": "^1.3.6",
     "minimatch": "^6.2.0",
     "mongochangestream": "^0.43.0",
     "node-fetch": "^3.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo2crate",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "description": "Sync MongoDB to CrateDB and Convert JSON schema to SQL DDL",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/convertSchema.test.ts
+++ b/src/convertSchema.test.ts
@@ -255,4 +255,54 @@ describe('convertSchema', () => {
   "metadata" OBJECT(IGNORED)
 )`)
   })
+  it('should rename fields in the schema', () => {
+    const result = convertSchema(schema, '"doc"."foobar"', {
+      rename: {
+        numberOfEmployees: 'numEmployees',
+        'integrations.stripe': 'integrations.payment',
+        'addresses.address': 'addresses.address1',
+      },
+    })
+    expect(result).toEqual(`CREATE TABLE IF NOT EXISTS "doc"."foobar" (
+  "id" TEXT PRIMARY KEY,
+  "name" TEXT,
+  "description" TEXT,
+  "numEmployees" TEXT,
+  "notificationPreferences" ARRAY (
+    TEXT
+  ),
+  "addresses" ARRAY (
+    OBJECT(STRICT) AS (
+      "address1" OBJECT(STRICT) AS (
+      ),
+      "street" TEXT,
+      "city" TEXT,
+      "county" TEXT,
+      "state" TEXT,
+      "zip" TEXT,
+      "country" TEXT,
+      "latitude" BIGINT,
+      "longitude" BIGINT,
+      "name" TEXT,
+      "isPrimary" BOOLEAN
+    )
+  ),
+  "integrations" OBJECT(DYNAMIC) AS (
+    "payment" OBJECT(DYNAMIC) AS (
+    ),
+    "priceId" BIGINT,
+    "subscriptionStatus" TEXT
+  ),
+  "metadata" OBJECT(IGNORED)
+)`)
+  })
+  it('should throw an exception if a rename field path prefix is different', () => {
+    expect(() =>
+      convertSchema(schema, '"doc"."foobar"', {
+        rename: {
+          'integrations.stripe': 'foo.bar',
+        },
+      })
+    ).toThrow()
+  })
 })

--- a/src/convertSchema.test.ts
+++ b/src/convertSchema.test.ts
@@ -259,7 +259,7 @@ describe('convertSchema', () => {
     const result = convertSchema(schema, '"doc"."foobar"', {
       rename: {
         numberOfEmployees: 'numEmployees',
-        'integrations.stripe': 'integrations.payment',
+        'integrations.stripe.subscriptionStatus': 'integrations.stripe.status',
         'addresses.address': 'addresses.address1',
       },
     })
@@ -274,24 +274,24 @@ describe('convertSchema', () => {
   "addresses" ARRAY (
     OBJECT(STRICT) AS (
       "address1" OBJECT(STRICT) AS (
+        "street" TEXT,
+        "city" TEXT,
+        "county" TEXT,
+        "state" TEXT,
+        "zip" TEXT,
+        "country" TEXT,
+        "latitude" BIGINT,
+        "longitude" BIGINT
       ),
-      "street" TEXT,
-      "city" TEXT,
-      "county" TEXT,
-      "state" TEXT,
-      "zip" TEXT,
-      "country" TEXT,
-      "latitude" BIGINT,
-      "longitude" BIGINT,
       "name" TEXT,
       "isPrimary" BOOLEAN
     )
   ),
   "integrations" OBJECT(DYNAMIC) AS (
-    "payment" OBJECT(DYNAMIC) AS (
-    ),
-    "priceId" BIGINT,
-    "subscriptionStatus" TEXT
+    "stripe" OBJECT(DYNAMIC) AS (
+      "priceId" BIGINT,
+      "status" TEXT
+    )
   ),
   "metadata" OBJECT(IGNORED)
 )`)

--- a/src/convertSchema.test.ts
+++ b/src/convertSchema.test.ts
@@ -303,6 +303,15 @@ describe('convertSchema', () => {
           'integrations.stripe': 'foo.bar',
         },
       })
-    ).toThrow()
+    ).toThrow('Rename path prefix does not match: integrations.stripe')
+  })
+  it('should throw an exception if a rename results in duplicate paths', () => {
+    expect(() =>
+      convertSchema(schema, '"doc"."foobar"', {
+        rename: {
+          'description': 'name',
+        },
+      })
+    ).toThrow('Duplicate paths found: name')
   })
 })

--- a/src/convertSchema.ts
+++ b/src/convertSchema.ts
@@ -138,17 +138,21 @@ const handleOverrides = (nodes: Node[], overrides: Override[]) => {
   return overriden
 }
 
+/**
+ * Modify path and key for relevant nodes.
+ */
 const handleRename = (nodes: Node[], rename: Record<string, string>) => {
-  for (const node of nodes) {
-    const dottedPath = node.path.join('.')
-    if (Object.hasOwn(rename, dottedPath)) {
-      const newPath = rename[dottedPath].split('.')
-      // Check if path prefixes do not match
-      if (!_.isEqual(node.path.slice(0, -1), newPath.slice(0, -1))) {
-        throw new Error(`Rename path prefix does not match: ${dottedPath}`)
+  for (const dottedPath in rename) {
+    const oldPath = dottedPath.split('.')
+    const newPath = rename[dottedPath].split('.')
+    if (!arrayStartsWith(oldPath, newPath.slice(0, -1))) {
+      throw new Error(`Rename path prefix does not match: ${dottedPath}`)
+    }
+    for (const node of nodes) {
+      if (arrayStartsWith(node.path, oldPath)) {
+        node.path.splice(0, oldPath.length, ...newPath)
+        node.key = node.path.at(-1)
       }
-      node.path = newPath
-      node.key = newPath.at(-1)
     }
   }
 }

--- a/src/convertSchema.ts
+++ b/src/convertSchema.ts
@@ -157,7 +157,7 @@ const cleanupPath = _.update('path', _.pull('_items'))
 
 /**
  * Convert MongoDB JSON schema to CrateDB table DDL.
- * Optionally, omit fields and change the BSON type for fields.
+ * Optionally, omit fields, rename fields, and change the BSON type for fields.
  * The latter is useful where a more-specific numeric type is needed.
  */
 export const convertSchema: ConvertSchema = (

--- a/src/convertSchema.ts
+++ b/src/convertSchema.ts
@@ -1,11 +1,12 @@
 import _ from 'lodash/fp.js'
 import { Node, walk } from 'obj-walker'
 import util from 'node:util'
-import { arrayStartsWith, getDupes } from './util.js'
+import { arrayStartsWith } from './util.js'
 import { Override, ConvertOptions } from './types.js'
 import { JSONSchema, traverseSchema } from 'mongochangestream'
 import { minimatch } from 'minimatch'
 import makeError from 'make-error'
+import { getDupes } from 'dupes-of-hazard'
 
 export const Mongo2CrateError = makeError('Mongo2CrateError')
 

--- a/src/convertSchema.ts
+++ b/src/convertSchema.ts
@@ -53,12 +53,8 @@ const _convertSchema = (nodes: Node[], spacing = ''): string => {
     if (!node) {
       return returnVal
     }
-    const isPrimaryKey = _.equals(node.path, ['_id'])
-    const field = isPrimaryKey
-      ? '"id" '
-      : node.key === '_items'
-      ? ''
-      : `"${node.key}" `
+    const isPrimaryKey = _.equals(node.path, ['id'])
+    const field = node.key === '_items' ? '' : `"${node.key}" `
     // Create table
     if (node.isRoot) {
       return (
@@ -173,9 +169,7 @@ export const convertSchema: ConvertSchema = (
   if (options.omit) {
     nodes = omitNodes(nodes, options.omit)
   }
-  if (options.rename) {
-    handleRename(nodes, options.rename)
-  }
+  handleRename(nodes, { ...options.rename, _id: 'id' })
   if (options.overrides) {
     nodes = handleOverrides(nodes, options.overrides)
   }

--- a/src/convertSchema.ts
+++ b/src/convertSchema.ts
@@ -43,7 +43,7 @@ const flagsToSql = (flags?: string[]) =>
     ? ' ' + flags.map((flag) => flagToSQL[flag]).join(' ')
     : ''
 
-const showCommaIf = (cond: boolean) => (cond ? ',' : '')
+const renderCommaIf = (cond: boolean) => (cond ? ',' : '')
 const padding = '  '
 
 const _convertSchema = (nodes: Node[], spacing = ''): string => {
@@ -68,7 +68,7 @@ const _convertSchema = (nodes: Node[], spacing = ''): string => {
     }
     // Scalar fields, including objects with no defined fields
     if (node.isLeaf) {
-      const comma = showCommaIf(nodes.length > 1)
+      const comma = renderCommaIf(nodes.length > 1)
       const sqlType = convertType(node.val.bsonType)
       const primary = isPrimaryKey ? ' PRIMARY KEY' : ''
       const modifiers = flagsToSql(node.val.flags)
@@ -83,7 +83,7 @@ const _convertSchema = (nodes: Node[], spacing = ''): string => {
       )
       const childNodes = nodes.slice(1, index + 1)
       const newSpacing = spacing + padding
-      const comma = showCommaIf(nodes.length - childNodes.length > 1)
+      const comma = renderCommaIf(nodes.length - childNodes.length > 1)
       const sqlType =
         node.val.bsonType === 'array'
           ? 'ARRAY'

--- a/src/syncData.ts
+++ b/src/syncData.ts
@@ -2,6 +2,7 @@ import type {
   ChangeStreamDocument,
   ChangeStreamInsertDocument,
   Collection,
+  Document,
 } from 'mongodb'
 import type { Redis } from 'ioredis'
 import mongoChangeStream, {
@@ -11,7 +12,7 @@ import mongoChangeStream, {
 import _ from 'lodash/fp.js'
 import { QueueOptions } from 'prom-utils'
 import { Crate, ErrorResult, QueryResult } from './crate.js'
-import { renameId, setDefaults, sumByRowcount } from './util.js'
+import { renameKeys, setDefaults, sumByRowcount } from './util.js'
 import {
   ConvertOptions,
   SyncOptions,
@@ -29,7 +30,8 @@ export const initSync = (
   crate: Crate,
   options: SyncOptions & mongoChangeStream.SyncOptions = {}
 ) => {
-  const mapper = options.mapper || renameId
+  const mapper = (doc: Document) =>
+    renameKeys(doc, { ...options.rename, _id: 'id' })
   const schemaName = options.schemaName || 'doc'
   const tableName = options.tableName || collection.collectionName.toLowerCase()
   const qualifiedName = `"${schemaName}"."${tableName}"`

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,3 @@
-import type { Document } from 'mongodb'
 import { JSONSchema } from 'mongochangestream'
 
 export interface ImmutableOption {
@@ -10,9 +9,9 @@ export interface ImmutableOption {
 }
 
 export interface SyncOptions {
-  mapper?: (doc: Document) => Document
   schemaName?: string
   tableName?: string
+  rename?: Record<string, string>
 }
 
 export interface Override extends Record<string, any> {
@@ -24,6 +23,7 @@ export interface Override extends Record<string, any> {
 export interface ConvertOptions {
   omit?: string[]
   overrides?: Override[]
+  rename?: Record<string, string>
 }
 
 export type Events = 'process' | 'error'

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export interface ImmutableOption {
 export interface SyncOptions {
   schemaName?: string
   tableName?: string
+  /** Nested paths should be dotted */
   rename?: Record<string, string>
 }
 
@@ -23,6 +24,7 @@ export interface Override extends Record<string, any> {
 export interface ConvertOptions {
   omit?: string[]
   overrides?: Override[]
+  /** Nested paths should be dotted */
   rename?: Record<string, string>
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,7 @@ export interface ImmutableOption {
 export interface SyncOptions {
   schemaName?: string
   tableName?: string
-  /** Nested paths should be dotted */
+  /** Dotted path to renamed dotted path */
   rename?: Record<string, string>
 }
 
@@ -24,7 +24,7 @@ export interface Override extends Record<string, any> {
 export interface ConvertOptions {
   omit?: string[]
   overrides?: Override[]
-  /** Nested paths should be dotted */
+  /** Dotted path to renamed dotted path */
   rename?: Record<string, string>
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -14,12 +14,6 @@ export const arrayStartsWith = (arr: any[], startsWith: any[]) => {
   return true
 }
 
-export const renameKey = (
-  obj: Record<string, any>,
-  key: string,
-  newKey: string
-) => _.flow(_.set(newKey, _.get(key, obj)), _.omit([key]))(obj)
-
 export const setDefaults = (keys: string[], val: any) => {
   const obj: Record<string, any> = {}
   for (const key of keys) {
@@ -28,8 +22,19 @@ export const setDefaults = (keys: string[], val: any) => {
   return obj
 }
 
-export const renameId = (doc: Document): Document =>
-  doc._id ? renameKey(doc, '_id', 'id') : doc
+export const renameKey = (doc: Document, key: string, newKey: string) =>
+  _.flow(_.set(newKey, _.get(key, doc)), _.omit([key]))(doc)
+
+export const renameKeys = (doc: Document, keys: Record<string, string>) => {
+  let newDoc = doc
+  for (const key in keys) {
+    if (_.has(key, doc)) {
+      const newKey = keys[key]
+      newDoc = renameKey(newDoc, key, newKey)
+    }
+  }
+  return newDoc
+}
 
 export const sumByRowcount = (num: number) =>
   _.sumBy(({ rowcount }) => (rowcount === num ? 1 : 0))

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,6 @@
 import { Document } from 'mongodb'
 import _ from 'lodash/fp.js'
+import stringify from 'json-stable-stringify'
 
 /**
  * Does arr start with startsWith array.
@@ -38,3 +39,22 @@ export const renameKeys = (doc: Document, keys: Record<string, string>) => {
 
 export const sumByRowcount = (num: number) =>
   _.sumBy(({ rowcount }) => (rowcount === num ? 1 : 0))
+
+/**
+ * Get a list of duplicate values from an array.
+ * TODO: Make this a separate NPM package.
+ */
+export function getDupes<T>(arr: T[]) {
+  const counts = new Map<string, number>()
+  const dupes = new Set<T>()
+  for (const item of arr) {
+    const stringifiedItem = stringify(item)
+    const currentCount = counts.get(stringifiedItem)
+    const newCount = currentCount ? currentCount + 1 : 1
+    counts.set(stringifiedItem, newCount)
+    if (newCount === 2) {
+      dupes.add(item)
+    }
+  }
+  return dupes
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,5 @@
 import { Document } from 'mongodb'
 import _ from 'lodash/fp.js'
-import stringify from 'json-stable-stringify'
 
 /**
  * Does arr start with startsWith array.
@@ -39,22 +38,3 @@ export const renameKeys = (doc: Document, keys: Record<string, string>) => {
 
 export const sumByRowcount = (num: number) =>
   _.sumBy(({ rowcount }) => (rowcount === num ? 1 : 0))
-
-/**
- * Get a list of duplicate values from an array.
- * TODO: Make this a separate NPM package.
- */
-export function getDupes<T>(arr: T[]) {
-  const counts = new Map<string, number>()
-  const dupes = new Set<T>()
-  for (const item of arr) {
-    const stringifiedItem = stringify(item)
-    const currentCount = counts.get(stringifiedItem)
-    const newCount = currentCount ? currentCount + 1 : 1
-    counts.set(stringifiedItem, newCount)
-    if (newCount === 2) {
-      dupes.add(item)
-    }
-  }
-  return dupes
-}


### PR DESCRIPTION
Removed `options.mapper` in favor of `options.rename` which takes an object of keys to be renamed.
The `rename` option is available for syncing and converting a schema to a table.