### PR TITLE
0.48.0: `mapSchema` option, chained overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.48.0
+
+-   Added a `mapSchema` option as an "escape hatch" to allow preprocessing each
+    node in the input object (using `map` from `obj-walker`) before converting
+    it to a Crate schema.
+
 # 0.47.0
 
 -   Breaking Change: Default to dynamic object policy in `convertSchema`. See docs on `strictMode` option.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # 0.48.0
 
+-   **Breaking Change**: When there are multiple `overrides` that match the same
+    path (e.g. `*` and `foo.*` both match the path `foo.bar`), they will now be
+    applied in sequence, where the output of each override is passed as input to
+    the next.
 -   Added a `mapSchema` option as an "escape hatch" to allow preprocessing each
     node in the input object (using `map` from `obj-walker`) before converting
     it to a Crate schema.
 
 # 0.47.0
 
--   Breaking Change: Default to dynamic object policy in `convertSchema`. See docs on `strictMode` option.
+-   **Breaking Change**: Default to dynamic object policy in `convertSchema`. See docs on `strictMode` option.
 -   Added `failedRecords` to `process` event and `failedRecord` to `error` for changestream events where applicable.
 -   Added `options.mapper` to `initSync`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo2crate",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "Sync MongoDB to CrateDB and Convert JSON schema to SQL DDL",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -70,8 +70,12 @@
     "semi": false,
     "singleQuote": true,
     "trailingComma": "es5",
-    "plugins": ["@trivago/prettier-plugin-sort-imports"],
-    "importOrder": ["^[./]"],
+    "plugins": [
+      "@trivago/prettier-plugin-sort-imports"
+    ],
+    "importOrder": [
+      "^[./]"
+    ],
     "importOrderSortSpecifiers": true,
     "importOrderCaseInsensitive": true,
     "importOrderSeparation": true

--- a/src/convertSchema.test.ts
+++ b/src/convertSchema.test.ts
@@ -232,7 +232,7 @@ describe('convertSchema', () => {
       overrides: [
         {
           path: '*',
-          mapper(obj) {
+          mapper: (obj) => {
             if (obj.bsonType === 'number') {
               return { ...obj, bsonType: 'double' }
             }
@@ -286,7 +286,7 @@ describe('convertSchema', () => {
         // PRECISION
         {
           path: '*',
-          mapper(obj) {
+          mapper: (obj) => {
             if (obj.bsonType === 'number') {
               return { ...obj, bsonType: 'double' }
             }

--- a/src/convertSchema.test.ts
+++ b/src/convertSchema.test.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash/fp.js'
 import { describe, expect, it } from 'vitest'
 
 import { convertSchema } from './convertSchema.js'
@@ -331,5 +332,187 @@ describe('convertSchema', () => {
         },
       })
     ).toThrow('Duplicate paths found: name')
+  })
+  describe('the `mapSchema` option', () => {
+    it('can be a no-op', () => {
+      expect(
+        convertSchema(schema, '"doc"."foobar"', { mapSchema: ({ val }) => val })
+      ).toEqual(
+        `CREATE TABLE IF NOT EXISTS "doc"."foobar" (
+  "id" TEXT PRIMARY KEY,
+  "name" TEXT,
+  "description" TEXT,
+  "numberOfEmployees" TEXT,
+  "notificationPreferences" ARRAY (
+    TEXT
+  ),
+  "addresses" ARRAY (
+    OBJECT(DYNAMIC) AS (
+      "address" OBJECT(DYNAMIC) AS (
+        "street" TEXT,
+        "city" TEXT,
+        "county" TEXT,
+        "state" TEXT,
+        "zip" TEXT,
+        "country" TEXT,
+        "latitude" BIGINT,
+        "longitude" BIGINT
+      ),
+      "name" TEXT,
+      "isPrimary" BOOLEAN
+    )
+  ),
+  "integrations" OBJECT(DYNAMIC) AS (
+    "stripe" OBJECT(DYNAMIC) AS (
+      "priceId" BIGINT,
+      "subscriptionStatus" TEXT
+    )
+  ),
+  "metadata" OBJECT(IGNORED)
+) WITH (column_policy = 'dynamic')`
+      )
+    })
+    it('can replace a leaf node', () => {
+      expect(
+        convertSchema(schema, '"doc"."foobar"', {
+          mapSchema: ({ path, val }) => {
+            if (
+              _.isEqual(path, [
+                'properties',
+                'addresses',
+                'items',
+                'properties',
+                'address',
+                'properties',
+                'zip',
+                'bsonType',
+              ])
+            ) {
+              // Was originally 'string'. In the expected output below, TEXT is
+              // replaced with BIGINT.
+              return 'number'
+            }
+
+            return val
+          },
+        })
+      ).toEqual(
+        `CREATE TABLE IF NOT EXISTS "doc"."foobar" (
+  "id" TEXT PRIMARY KEY,
+  "name" TEXT,
+  "description" TEXT,
+  "numberOfEmployees" TEXT,
+  "notificationPreferences" ARRAY (
+    TEXT
+  ),
+  "addresses" ARRAY (
+    OBJECT(DYNAMIC) AS (
+      "address" OBJECT(DYNAMIC) AS (
+        "street" TEXT,
+        "city" TEXT,
+        "county" TEXT,
+        "state" TEXT,
+        "zip" BIGINT,
+        "country" TEXT,
+        "latitude" BIGINT,
+        "longitude" BIGINT
+      ),
+      "name" TEXT,
+      "isPrimary" BOOLEAN
+    )
+  ),
+  "integrations" OBJECT(DYNAMIC) AS (
+    "stripe" OBJECT(DYNAMIC) AS (
+      "priceId" BIGINT,
+      "subscriptionStatus" TEXT
+    )
+  ),
+  "metadata" OBJECT(IGNORED)
+) WITH (column_policy = 'dynamic')`
+      )
+    })
+    it('can replace a non-leaf node', () => {
+      expect(
+        convertSchema(schema, '"doc"."foobar"', {
+          mapSchema: ({ path, val }) => {
+            if (_.isEqual(path, ['properties', 'addresses', 'items'])) {
+              // This should result in OBJECT(IGNORED), since there are no
+              // properties.
+              return { bsonType: 'object' }
+            }
+
+            return val
+          },
+        })
+      ).toEqual(
+        `CREATE TABLE IF NOT EXISTS "doc"."foobar" (
+  "id" TEXT PRIMARY KEY,
+  "name" TEXT,
+  "description" TEXT,
+  "numberOfEmployees" TEXT,
+  "notificationPreferences" ARRAY (
+    TEXT
+  ),
+  "addresses" ARRAY (
+    OBJECT(IGNORED)
+  ),
+  "integrations" OBJECT(DYNAMIC) AS (
+    "stripe" OBJECT(DYNAMIC) AS (
+      "priceId" BIGINT,
+      "subscriptionStatus" TEXT
+    )
+  ),
+  "metadata" OBJECT(IGNORED)
+) WITH (column_policy = 'dynamic')`
+      )
+    })
+    it('can remove nodes', () => {
+      expect(
+        convertSchema(schema, '"doc"."foobar"', {
+          mapSchema: ({ path, val }) => {
+            if (
+              _.isEqual(path, [
+                'properties',
+                'addresses',
+                'items',
+                'additionalProperties',
+              ]) ||
+              _.isEqual(path, [
+                'properties',
+                'addresses',
+                'items',
+                'properties',
+              ])
+            ) {
+              // This should result in OBJECT(IGNORED), since we removed the
+              // properties.
+              return undefined
+            }
+
+            return val
+          },
+        })
+      ).toEqual(
+        `CREATE TABLE IF NOT EXISTS "doc"."foobar" (
+  "id" TEXT PRIMARY KEY,
+  "name" TEXT,
+  "description" TEXT,
+  "numberOfEmployees" TEXT,
+  "notificationPreferences" ARRAY (
+    TEXT
+  ),
+  "addresses" ARRAY (
+    OBJECT(IGNORED)
+  ),
+  "integrations" OBJECT(DYNAMIC) AS (
+    "stripe" OBJECT(DYNAMIC) AS (
+      "priceId" BIGINT,
+      "subscriptionStatus" TEXT
+    )
+  ),
+  "metadata" OBJECT(IGNORED)
+) WITH (column_policy = 'dynamic')`
+      )
+    })
   })
 })

--- a/src/convertSchema.test.ts
+++ b/src/convertSchema.test.ts
@@ -393,44 +393,6 @@ describe('convertSchema', () => {
     ).toThrow('Duplicate paths found: name')
   })
   describe('the `mapSchema` option', () => {
-    it('can be a no-op', () => {
-      expect(
-        convertSchema(schema, '"doc"."foobar"', { mapSchema: ({ val }) => val })
-      ).toEqual(
-        `CREATE TABLE IF NOT EXISTS "doc"."foobar" (
-  "id" TEXT PRIMARY KEY,
-  "name" TEXT,
-  "description" TEXT,
-  "numberOfEmployees" TEXT,
-  "notificationPreferences" ARRAY (
-    TEXT
-  ),
-  "addresses" ARRAY (
-    OBJECT(DYNAMIC) AS (
-      "address" OBJECT(DYNAMIC) AS (
-        "street" TEXT,
-        "city" TEXT,
-        "county" TEXT,
-        "state" TEXT,
-        "zip" TEXT,
-        "country" TEXT,
-        "latitude" BIGINT,
-        "longitude" BIGINT
-      ),
-      "name" TEXT,
-      "isPrimary" BOOLEAN
-    )
-  ),
-  "integrations" OBJECT(DYNAMIC) AS (
-    "stripe" OBJECT(DYNAMIC) AS (
-      "priceId" BIGINT,
-      "subscriptionStatus" TEXT
-    )
-  ),
-  "metadata" OBJECT(IGNORED)
-) WITH (column_policy = 'dynamic')`
-      )
-    })
     it('can replace a leaf node', () => {
       expect(
         convertSchema(schema, '"doc"."foobar"', {
@@ -479,89 +441,6 @@ describe('convertSchema', () => {
       "name" TEXT,
       "isPrimary" BOOLEAN
     )
-  ),
-  "integrations" OBJECT(DYNAMIC) AS (
-    "stripe" OBJECT(DYNAMIC) AS (
-      "priceId" BIGINT,
-      "subscriptionStatus" TEXT
-    )
-  ),
-  "metadata" OBJECT(IGNORED)
-) WITH (column_policy = 'dynamic')`
-      )
-    })
-    it('can replace a non-leaf node', () => {
-      expect(
-        convertSchema(schema, '"doc"."foobar"', {
-          mapSchema: ({ path, val }) => {
-            if (_.isEqual(path, ['properties', 'addresses', 'items'])) {
-              // This should result in OBJECT(IGNORED), since there are no
-              // properties.
-              return { bsonType: 'object' }
-            }
-
-            return val
-          },
-        })
-      ).toEqual(
-        `CREATE TABLE IF NOT EXISTS "doc"."foobar" (
-  "id" TEXT PRIMARY KEY,
-  "name" TEXT,
-  "description" TEXT,
-  "numberOfEmployees" TEXT,
-  "notificationPreferences" ARRAY (
-    TEXT
-  ),
-  "addresses" ARRAY (
-    OBJECT(IGNORED)
-  ),
-  "integrations" OBJECT(DYNAMIC) AS (
-    "stripe" OBJECT(DYNAMIC) AS (
-      "priceId" BIGINT,
-      "subscriptionStatus" TEXT
-    )
-  ),
-  "metadata" OBJECT(IGNORED)
-) WITH (column_policy = 'dynamic')`
-      )
-    })
-    it('can remove nodes', () => {
-      expect(
-        convertSchema(schema, '"doc"."foobar"', {
-          mapSchema: ({ path, val }) => {
-            if (
-              _.isEqual(path, [
-                'properties',
-                'addresses',
-                'items',
-                'additionalProperties',
-              ]) ||
-              _.isEqual(path, [
-                'properties',
-                'addresses',
-                'items',
-                'properties',
-              ])
-            ) {
-              // This should result in OBJECT(IGNORED), since we removed the
-              // properties.
-              return undefined
-            }
-
-            return val
-          },
-        })
-      ).toEqual(
-        `CREATE TABLE IF NOT EXISTS "doc"."foobar" (
-  "id" TEXT PRIMARY KEY,
-  "name" TEXT,
-  "description" TEXT,
-  "numberOfEmployees" TEXT,
-  "notificationPreferences" ARRAY (
-    TEXT
-  ),
-  "addresses" ARRAY (
-    OBJECT(IGNORED)
   ),
   "integrations" OBJECT(DYNAMIC) AS (
     "stripe" OBJECT(DYNAMIC) AS (

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import { JSONSchema } from 'mongochangestream'
 import type { ChangeStreamDocument, Document } from 'mongodb'
-import { Node } from 'obj-walker'
+import { Mapper, Node } from 'obj-walker'
 
 interface RenameOption {
   /** Dotted path to renamed dotted path */
@@ -42,6 +42,28 @@ export interface Override extends Record<string, any> {
 }
 
 export interface ConvertOptions extends RenameOption {
+  /**
+   * An obj-walker Mapper function that can be used as an "escape hatch" to
+   * preprocess each node in the object (using `map`) before using `walk` to
+   * convert the object into the output Crate schema.
+   *
+   * This can be useful in situations where you want to replace or remove a
+   * non-leaf node.
+   *
+   * @example
+   * ```typescript
+   * const mapSchema = ({ path, val }) => {
+   *   if (_.isEqual(path, ['properties', 'addresses', 'items'])) {
+   *     // This should result in OBJECT(IGNORED), since there are no
+   *     // properties.
+   *     return { bsonType: 'object' }
+   *   }
+   *
+   *   return val
+   * }
+   * ```
+   */
+  mapSchema?: Mapper
   omit?: string[]
   overrides?: Override[]
   /**


### PR DESCRIPTION
GS-8604, GS-8605

Following our discussion last week, this adds a `mapSchema` option to allow preprocessing nodes (using `map` from `obj-walker`) in the input object before converting it to a Crate schema.

(I'm about to look at adding this same option to `mongo2elastic` as well.)