### PR TITLE
0.55.0: Bump mongochangestream to pick up refresh token improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.55.0
+
+- Latest `mongochangestream` - Performance improvements related to updating the
+  refresh token more often. See [mongochangestream
+  changelog](https://github.com/smartprocure/mongochangestream/blob/master/CHANGELOG.md#0590)
+
 # 0.54.0
 
 - Latest `mongochangestream` - Move retry logic to `mongochangestream`.

--- a/README.md
+++ b/README.md
@@ -201,3 +201,5 @@ MONGO_CONN="mongodb+srv://..."
 SQL_ENDPOINT='https://foo.bar:4200/_sql'
 AUTH='username:password'
 ```
+
+Then run `npm test` to run the tests.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "eventemitter3": "^5.0.1",
         "lodash": "^4.17.21",
         "minimatch": "^10.0.1",
-        "mongochangestream": "^0.58.0",
+        "mongochangestream": "^0.59.0",
         "ms": "^2.1.3",
         "node-fetch": "^3.3.2",
         "obj-walker": "^2.4.0",
@@ -2801,9 +2801,10 @@
       }
     },
     "node_modules/mongochangestream": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/mongochangestream/-/mongochangestream-0.58.0.tgz",
-      "integrity": "sha512-UUs3JsyKORSJjqwg6ADV8GBYSptIHPO1I+E0RhFjjKk3B/14lgLb5OcKZrYo3DYg+ObysVZw2bkPPGzkdsuNcw==",
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/mongochangestream/-/mongochangestream-0.59.0.tgz",
+      "integrity": "sha512-MJBvX5YUXvv3/Hrl+fYlQ3AXFJaKJnUIyP3w3vkPyNAbvFSEZdmalaGKDlR2KHmM0osh5vTKUu/sq+QnFYlL0A==",
+      "license": "ISC",
       "dependencies": {
         "debug": "^4.4.0",
         "eventemitter3": "^5.0.1",
@@ -5569,9 +5570,9 @@
       }
     },
     "mongochangestream": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/mongochangestream/-/mongochangestream-0.58.0.tgz",
-      "integrity": "sha512-UUs3JsyKORSJjqwg6ADV8GBYSptIHPO1I+E0RhFjjKk3B/14lgLb5OcKZrYo3DYg+ObysVZw2bkPPGzkdsuNcw==",
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/mongochangestream/-/mongochangestream-0.59.0.tgz",
+      "integrity": "sha512-MJBvX5YUXvv3/Hrl+fYlQ3AXFJaKJnUIyP3w3vkPyNAbvFSEZdmalaGKDlR2KHmM0osh5vTKUu/sq+QnFYlL0A==",
       "requires": {
         "debug": "^4.4.0",
         "eventemitter3": "^5.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mongo2crate",
-  "version": "0.54.0",
+  "version": "0.55.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mongo2crate",
-      "version": "0.54.0",
+      "version": "0.55.0",
       "license": "ISC",
       "dependencies": {
         "debug": "^4.4.0",
@@ -29,7 +29,7 @@
         "@types/node": "^22.10.5",
         "@typescript-eslint/eslint-plugin": "^8.19.1",
         "globals": "^15.14.0",
-        "mongochangestream-testing": "^0.3.0",
+        "mongochangestream-testing": "^0.5.0",
         "prettier": "^3.4.2",
         "typescript": "5.7.3",
         "vitest": "^2.1.8"
@@ -2824,13 +2824,15 @@
       }
     },
     "node_modules/mongochangestream-testing": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/mongochangestream-testing/-/mongochangestream-testing-0.3.0.tgz",
-      "integrity": "sha512-uWLMj75IAhvBxMFCRGdFeQ0yhNSC0VbpMC1RYq0IYuLr1u9oHOvwN0uXmOF8EHZyVs0PVbkXHgdq7lvbbZ3mdA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/mongochangestream-testing/-/mongochangestream-testing-0.5.0.tgz",
+      "integrity": "sha512-n2hNIs4NG9rmne7v30cPzVIhb7P2xI0o/6fVc7qlWJtBb7j94CQZJylx+w5FzJs1BeHtONsypnDatSGuzwSKYg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "@faker-js/faker": "^9.3.0",
-        "mongodb": "^6.12.0"
+        "mongodb": "^6.12.0",
+        "prom-utils": "^0.14.0"
       }
     },
     "node_modules/mongodb": {
@@ -5585,13 +5587,14 @@
       }
     },
     "mongochangestream-testing": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/mongochangestream-testing/-/mongochangestream-testing-0.3.0.tgz",
-      "integrity": "sha512-uWLMj75IAhvBxMFCRGdFeQ0yhNSC0VbpMC1RYq0IYuLr1u9oHOvwN0uXmOF8EHZyVs0PVbkXHgdq7lvbbZ3mdA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/mongochangestream-testing/-/mongochangestream-testing-0.5.0.tgz",
+      "integrity": "sha512-n2hNIs4NG9rmne7v30cPzVIhb7P2xI0o/6fVc7qlWJtBb7j94CQZJylx+w5FzJs1BeHtONsypnDatSGuzwSKYg==",
       "dev": true,
       "requires": {
         "@faker-js/faker": "^9.3.0",
-        "mongodb": "^6.12.0"
+        "mongodb": "^6.12.0",
+        "prom-utils": "^0.14.0"
       }
     },
     "mongodb": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@types/node": "^22.10.5",
     "@typescript-eslint/eslint-plugin": "^8.19.1",
     "globals": "^15.14.0",
-    "mongochangestream-testing": "^0.3.0",
+    "mongochangestream-testing": "^0.5.0",
     "prettier": "^3.4.2",
     "typescript": "5.7.3",
     "vitest": "^2.1.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo2crate",
-  "version": "0.54.0",
+  "version": "0.55.0",
   "description": "Sync MongoDB to CrateDB and Convert JSON schema to SQL DDL",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -57,7 +57,7 @@
     "eventemitter3": "^5.0.1",
     "lodash": "^4.17.21",
     "minimatch": "^10.0.1",
-    "mongochangestream": "^0.58.0",
+    "mongochangestream": "^0.59.0",
     "ms": "^2.1.3",
     "node-fetch": "^3.3.2",
     "obj-walker": "^2.4.0",

--- a/src/syncData.test.ts
+++ b/src/syncData.test.ts
@@ -2,51 +2,17 @@ import debug from 'debug'
 import Redis from 'ioredis'
 import _ from 'lodash/fp.js'
 import {
+  assertEventually,
   initState as initRedisAndMongoState,
   numDocs,
 } from 'mongochangestream-testing'
 import { type Db, MongoClient } from 'mongodb'
 import ms from 'ms'
 import { setTimeout } from 'node:timers/promises'
-import { TimeoutError, WaitOptions, waitUntil } from 'prom-utils'
 import { assert, describe, expect, test } from 'vitest'
 
 import * as mongo2crate from './index.js'
 import { type SyncOptions } from './index.js'
-
-// FIXME: Pull in `assertEventually` from mongochangestream-testing instead.
-
-/**
- * Asserts that the provided predicate eventually returns true.
- *
- * @param pred - The predicate to check: an async function returning a boolean.
- * @param failureMessage - The message to display if the predicate does not
- * return true before the timeout.
- * @param [waitOptions] - Options to override the default options passed into
- * `waitUntil`.
- *
- * @throws AssertionError if the predicate does not return true before the
- * timeout.
- */
-export const assertEventually = async (
-  pred: () => Promise<boolean>,
-  failureMessage = 'Failed to satisfy predicate',
-  waitOptions: WaitOptions = {}
-) => {
-  try {
-    await waitUntil(pred, {
-      timeout: ms('60s'),
-      checkFrequency: ms('50ms'),
-      ...waitOptions,
-    })
-  } catch (e) {
-    if (e instanceof TimeoutError) {
-      assert.fail(failureMessage)
-    } else {
-      throw e
-    }
-  }
-}
 
 // Output via console.info (stdout) instead of stderr.
 // Without this debug statements are swallowed by vitest.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,6 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig(({ mode }) => ({
   test: {
     env: loadEnv(mode, process.cwd(), ''),
-    testTimeout: 30000,
+    testTimeout: 60000,
   },
 }))


### PR DESCRIPTION
This bumps the mongochangestream dependency to pick up the refresh token related improvements (https://github.com/smartprocure/mongochangestream/pull/37).

I ran the tests and they all passed except this one:

```
FAIL  src/syncData.test.ts > syncCollection > should process records via change stream
AssertionError: expected 31 to be 100 // Object.is equality

- Expected
+ Received

- 100
+ 31
```

However, I don't think this is related to the changes, because I also ran the tests on the master branch and the same test failed.

EDIT: Likely latency related. I changed the following line to 20 seconds, and the test case passed:

```typescript
    // Wait for the change stream events to be processed
    await setTimeout(ms('8s'))
```

Update 2025-02-28: Tests are all passing with `assertEventually` in place to account for my current poor latency.